### PR TITLE
add Dirac GOS for EELS quantification

### DIFF
--- a/EELS/EELS_analysis.ipynb
+++ b/EELS/EELS_analysis.ipynb
@@ -22,6 +22,7 @@
     "* 20/7/2019 Katherine MacArthur - Checked for Hyperspy 1.5.1 and commented out sections requiring Gatan GOS files.\n",
     "* 30/7/2019 Magnus Nord - Minor text improvements for M&M19 short course\n",
     "* 9/3/2024 Magnus Nord - Updated to work with HyperSpy 2.0.0\n",
+    "* 23/8/2024 Zezhong Zhang - Add Dirac GOS example in curve fitting quantification\n",
     "\n",
     "## Table of contents\n",
     "\n",
@@ -757,6 +758,76 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "By default, exspy uses the [DFT GOS](https://zenodo.org/records/7645765) based on the Schrödinger equation. As alternative, we can also use the [Dirac GOS](https://zenodo.org/records/12800856) to include the relativistic effects, as described in this [arxiv paper](https://arxiv.org/pdf/2405.10151). The switch of the GOS is simply done by assigning the `GOS` parameter when creating the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_dirac = s.create_model(low_loss=s_ll, GOS='dirac')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot the difference between the two GOS models for each edge, where the solid lines are Dirac results and dashed lines are DFT results. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.figure()\n",
+    "edges = (\"Ti_L3\", \"Mn_L3\", \"O_K\", \"La_M5\")\n",
+    "color_list = [\"r\", \"g\", \"b\", \"k\"]\n",
+    "for edge in edges:\n",
+    "    color = color_list.pop()\n",
+    "    plt.plot(m_dirac[edge].GOS.energy_axis, m_dirac[edge].GOS.qint, label=edge + \" (Dirac)\", color=color)\n",
+    "    plt.plot(m[edge].GOS.energy_axis, m[edge].GOS.qint, label=edge + \" (DFT)\", color=color, linestyle=\"--\")\n",
+    "plt.xlim(400, 1000)\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "plt.xlabel(\"Energy loss (eV)\")\n",
+    "plt.ylabel(\"Scattering cross-section (barn/eV)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also compare the quantification line profiles:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_dirac.components.O_K.onset_energy.value = 528\n",
+    "m_dirac.components.O_K.onset_energy.assign_current_value_to_all()\n",
+    "m_dirac.components.Mn_L3.onset_energy.value\n",
+    "m_dirac.components.Mn_L3.onset_energy.value = 638.5\n",
+    "m_dirac.components.Mn_L3.onset_energy.assign_current_value_to_all()\n",
+    "m_dirac.enable_fine_structure()\n",
+    "m_dirac.multifit(kind='smart')\n",
+    "edges = (\"Ti_L3\", \"Mn_L3\", \"O_K\", \"La_M5\")\n",
+    "linestyle_list = ['-']* len(edges) + ['--']* len(edges)\n",
+    "color_list = ['r', 'g', 'b', 'k']*2\n",
+    "hs.plot.plot_spectra([m_dirac[edge].intensity.as_signal() for edge in edges] + [m[edge].intensity.as_signal() for edge in edges], legend=edges, linestyle=linestyle_list, color=color_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# <a id='fine_structure_analysis'></a> 4. Fine structure analysis"
    ]
   },
@@ -1024,7 +1095,7 @@
    },
    "outputs": [],
    "source": [
-    "m = s.create_model(low_loss=s_ll, auto_background=False)"
+    "m = s.create_model(low_loss=s_ll, auto_background=False, GOS='dirac')"
    ]
   },
   {
@@ -1506,7 +1577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/EELS/EELS_elemental_mapping.ipynb
+++ b/EELS/EELS_elemental_mapping.ipynb
@@ -25,7 +25,8 @@
     "\n",
     "* 2017/09/27: Initial version by Ida Hjorth\n",
     "* 2019/11/14: Update to HyperSpy 1.5, and minor improvements to text by Magnus Nord\n",
-    "* 2024/3/16: Update to work with HyperSpy 2.0, by Magnus Nord"
+    "* 2024/3/16: Update to work with HyperSpy 2.0, by Magnus Nord\n",
+    "* 23/8/2024 Zezhong Zhang - Add Dirac GOS example in mapping"
    ]
   },
   {
@@ -442,6 +443,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "By default, exspy utilizes the [DFT GOS](https://zenodo.org/records/7645765), which is based on the Schrödinger equation. However, if you need to account for relativistic effects, you can switch to the [Dirac GOS](https://zenodo.org/records/12800856), as detailed in this [arxiv paper](https://arxiv.org/pdf/2405.10151). Changing the GOS is straightforward; you can do this by setting the GOS parameter when creating the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_dirac = s_eels.create_model(GOS='dirac')\n",
+    "m.fit_component(m.components.PowerLaw, signal_range=(700, 900), only_current=False)\n",
+    "m_dirac.fit_component(m_dirac.components.Cu_L3, signal_range=(950, 1000), only_current=False)\n",
+    "m_dirac.fit_component(m_dirac.components.Zn_L3, signal_range=(1050, 1150), only_current=False)\n",
+    "m_dirac.set_all_edges_intensities_positive()\n",
+    "m_dirac.multifit()\n",
+    "Zn_map_dirac = m_dirac.components.Zn_L3.intensity.as_signal()\n",
+    "Cu_map_dirac = m_dirac.components.Cu_L3.intensity.as_signal()\n",
+    "hs.plot.plot_images([Zn_map_dirac, Cu_map_dirac])\n",
+    "plt.savefig(\"Zn_Cu_elemental_maps_dirac.png\")\n",
+    "hs.plot.plot_images([Zn_map_dirac, Cu_map_dirac], overlay=True, label=[\"Zn\", \"Cu\"], axes_decor=\"off\")\n",
+    "plt.savefig(\"Zn_Cu_elemental_maps_overlay_dirac.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# 4. <a id='save_restore'></a>Saving and restoring the models"
    ]
   },
@@ -518,7 +546,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As mentioned in https://github.com/hyperspy/hyperspy/discussions/3399#discussioncomment-10388074, here adds the examples for using Dirac GOS for EELS quantification. It includes:
- short text description and links to the databases
- compare the cross-sections for different edges between the Dirac and DFT GOS 
- line profile comparison 
- elemental maps
This is done in a very simple manner of passing `GOS` parameter during model creation and re-use of the previous quantification procedure and code (in a single jupyter cell), as I think the main purpose of the notebooks are showing users how to use exspy for quantification instead of detailed explanation of the GOS, but please let me know if further details are needed. 